### PR TITLE
Add os_authType query parameter for bamboo

### DIFF
--- a/src/core/services/bamboo/bambooPlan.js
+++ b/src/core/services/bamboo/bambooPlan.js
@@ -43,6 +43,7 @@ define([
 	var plan = function (self) {
 		return request.json({
 			url: joinUrl(self.settings.url, 'rest/api/latest/plan/' + self.id),
+			data: {os_authType: 'basic'},
 			username: self.settings.username,
 			password: self.settings.password,
 			authCookie: 'JSESSIONID'
@@ -52,6 +53,7 @@ define([
 	var result = function (self) {
 		return request.json({
 			url: joinUrl(self.settings.url, 'rest/api/latest/result/' + self.id + '/latest?expand=changes'),
+			data: {os_authType: 'basic'},
 			username: self.settings.username,
 			password: self.settings.password,
 			authCookie: 'JSESSIONID'

--- a/src/core/services/bamboo/bambooPlan.spec.js
+++ b/src/core/services/bamboo/bambooPlan.spec.js
@@ -46,7 +46,9 @@ define([
 			expect(request.json.calls[0].args[0].username).toBe(settings.username);
 			expect(request.json.calls[0].args[0].password).toBe(settings.password);
 			expect(request.json.calls[0].args[0].authCookie).toBe('JSESSIONID');
+			expect(request.json.calls[0].args[0].data).toEqual({os_authType: 'basic'});
 			expect(request.json.calls[1].args[0].url).toBe('http://example.com/rest/api/latest/result/KEY/latest?expand=changes');
+			expect(request.json.calls[1].args[0].data).toEqual({os_authType: 'basic'});
 		});
 
 		it('should parse response and return current state', function () {


### PR DESCRIPTION
According to https://developer.atlassian.com/display/BAMBOODEV/Using+the+Bamboo+REST+APIs#UsingtheBambooRESTAPIs-authenticateRESTAuthentication
basic auth won't work unless this query parameter is set to basic.
This resulted in the plugin not working until I manually loaded the
build page in my browser once.

Fixes #18