### PR TITLE
update doc to use grunt-cli

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,11 +65,11 @@ Installation
 ------------
 
 1. Install [Node.js](http://nodejs.org/) to build the extension.
-2. Install Bower globally `npm install -g bower` 
+2. Install Bower globally `npm install -g bower grunt-cli` 
 3. Go to project directory `/git/BuildReactor/` and run:
  - `npm install`
  - `bower update`
- - `/node_modules/.bin/grunt`
+ - `grunt`
 4. Open Chrome Extension manager and `Load unpacked extension..` from `_build/BuildReactor` folder.
 
 

--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ Installation
 ------------
 
 1. Install [Node.js](http://nodejs.org/) to build the extension.
-2. Install Bower globally `npm install -g bower grunt-cli` 
+2. `npm install -g bower grunt-cli` 
 3. Go to project directory `/git/BuildReactor/` and run:
  - `npm install`
  - `bower update`


### PR DESCRIPTION
Hi Adam,

I try to do developer setup for BuildReactor today and I notice that in readme file, it says to run `/node_modules/.bin/grunt`. I think use grunt-cli is more easy to do this, rather than just call grunt in ‘.bin’ folder directly.

so I update the readme file to install grunt-cli first and run `grunt` command.

http://gruntjs.com/getting-started#installing-the-cli

