### PR TITLE
added support for WorkflowMultiBranchProjects

### DIFF
--- a/src/services/jenkins/jenkins.js
+++ b/src/services/jenkins/jenkins.js
@@ -51,6 +51,14 @@ export default {
                             group: job.name,
                             isDisabled: !jobDetails.buildable
                         }));
+                case WorkflowMultiBranchProject:
+                    return Rx.Observable.fromArray(job.jobs)
+                        .select((jobDetails) => ({
+                            id: jobDetails.fullName,
+                            name: `${jobDetails.name}`,
+                            group: job.name,
+                            isDisabled: !jobDetails.buildable
+                        }));
                 default:
                     // FreeStyleProject or jenkins 1.x project
                     return Rx.Observable.return({

--- a/src/services/jenkins/jenkins.spec.js
+++ b/src/services/jenkins/jenkins.spec.js
@@ -111,6 +111,24 @@ describe('services/jenkins/jenkins', () => {
                     group: null,
                     isDisabled: false
                 }),
+                onNext(200, {
+                    id: 'job23/master',
+                    name: 'master',
+                    group: 'job23',
+                    isDisabled: false
+                }),
+                onNext(200, {
+                    id: 'job23/myFeatureBranch',
+                    name: 'myFeatureBranch',
+                    group: 'job23',
+                    isDisabled: false
+                }),
+                onNext(200, {
+                    id: 'job23/myOtherFeatureBranch',
+                    name: 'myOtherFeatureBranch',
+                    group: 'job23',
+                    isDisabled: true
+                }),
                 onCompleted(200)
             );
         });

--- a/src/services/jenkins/jobs-2x.fixture.json
+++ b/src/services/jenkins/jobs-2x.fixture.json
@@ -48,5 +48,33 @@
         "url": "https://jenkins.sample/jenkins/job/freestyle-project/",
         "buildable": true,
         "inQueue": false
+    }, {
+      "_class": "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject",
+      "fullName": "job23",
+      "name": "job23",
+      "url": "https://jenkins.sample/job/job23/",
+      "jobs": [
+        {
+          "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+          "fullName": "job23/master",
+          "name": "master",
+          "url": "https://jenkins.sample/job/job23/job/master/",
+          "buildable": true
+        },
+        {
+          "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+          "fullName": "job23/myFeatureBranch",
+          "name": "myFeatureBranch",
+          "url": "https://jenkins.sample/job/job23/job/myFeatureBranch/",
+          "buildable": true
+        },
+        {
+          "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+          "fullName": "job23/myOtherFeatureBranch",
+          "name": "myOtherFeatureBranch",
+          "url": "https://jenkins.sample/job/job23/job/myOtherFeatureBranch/",
+          "buildable": false
+        }
+      ]
     }]
 }


### PR DESCRIPTION
ISSUE-75
Took a crack at fixing [ISSUE 75](https://github.com/AdamNowotny/BuildReactor/issues/75) 

It looks like the WorkflowMultiBranchProject was the job._class, not the project._class.  I'm not sure if there should be any changes to the OrganizationalFolder case of the switch statement.

One issue i noticed is that the group functionality is "cumbersome" I don't know if it's something I caused. I haven't checked the issues list yet. If this code is causing the problem, i'd like to get it fixed, otherwise i guess I can creating some issues: 

- Check boxes are a little funky.  The project checkbox will be checked, but no sub jobs are. 
- Search is weak.  If I have a WorkflowMultiBranchProject named Foo and with branches, master, dev, and prod, searching for Foo won't hit on the project name. 
- Save functionality isn't updating the monitored builds section. 

It's probably worh mentioning that my organization has the most amount of jobs I've ever seen. There's got to be upwards of 400 of them. Most of them are WorkflowMultiBranchProject jobs and they'll easily have 4-5 branches in each one. 